### PR TITLE
Recommending change to >=1.1.7 for BiblioPixel

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-BiblioPixel==1.1.7
+BiblioPixel>=1.1.7
 RPi.GPIO==0.5.11
 jenkinsapi==0.2.27
 pyserial==2.7


### PR DESCRIPTION
Awesome work! Always love seeing my libraries in action :)
Just thought I'd recommend a quick tweak to the requirements since BiblioPixel is up to v1.2.1, for which there are no breaking API changes, so it's safe.
